### PR TITLE
fastly.py: Use `grequests` module to asynchronously do the requests first (performance boost)

### DIFF
--- a/fastly.py
+++ b/fastly.py
@@ -5,12 +5,12 @@
 # Copyright (c) 2016, InnoGames GmbH
 #
 
-import sys
+import argparse
 import json
+import sys
+import time
 import urllib
 import urllib2
-import argparse
-import time
 
 GRAPHITE_PREFIX = 'cdn.fastly'
 FASTLY_BASE_URL = 'https://api.fastly.com'


### PR DESCRIPTION
After I saw the performance boost in highwinds script I wanted to change fastly script to use that too.

Also I found a bug while implementing it as I got far more information back than in the previous version. The service variable was accidentally overwritten in a for loop, so after the first loop information for just one service was fetched then.
In this PR this bug would be automatically be fixed.