### PR TITLE
Convert rss to bytes

### DIFF
--- a/src/processes.py
+++ b/src/processes.py
@@ -32,7 +32,7 @@ def main():
                 print(template.format(command, 'cpu_usage', process.pcpu))
                 print(template.format(command, 'mem_usage', process.pmem))
                 print(template.format(command, 'etimes', process.etimes))
-                print(template.format(command, 'rss', process.rss))
+                print(template.format(command, 'rss', int(process.rss) * 1024))
                 break
 
 


### PR DESCRIPTION
ps gives you output in Kilobytes, which is pretty bad, because you need to perform extra magic within graphite to convert it to other units.