### PR TITLE
Ignore views in tables size calculating

### DIFF
--- a/src/mysql.py
+++ b/src/mysql.py
@@ -53,8 +53,8 @@ def main():
     # Find out how much space we can recover by Optimize
     sysdbs = {
         'information_schema',
-        'performance_schema',
         'mysql',
+        'performance_schema',
         'sys',
         'test',
     }
@@ -68,7 +68,8 @@ def main():
             'ROUND(data_free / 1024 / 1024), '
             'ROUND((data_length + index_length), 2) '
             'FROM information_schema.tables '
-            'WHERE table_schema = %s',
+            'WHERE table_type = "BASE TABLE" '
+            'AND table_schema = %s',
             [row[0]]
         )
         for value in cur.fetchall():


### PR DESCRIPTION
```                            table_name: bi_resource
        ROUND(data_free / 1024 / 1024): NULL
ROUND((data_length + index_length), 2): NULL```

It causes:
```  File "/usr/share/igcollect/mysql.py", line 81, in <module>
    main()
  File "/usr/share/igcollect/mysql.py", line 76, in main
    free += value[1]
TypeError: unsupported operand type(s) for +=: 'Decimal' and 'NoneType'```