### PR TITLE
Allow floats for percentage calculations

### DIFF
--- a/igcollect/logfile_values.py
+++ b/igcollect/logfile_values.py
@@ -132,9 +132,9 @@ class Metric:
                     if 'percentage' in self.function:
                         return float(
                             self.get_count_percentage(
-                                int(self.function.split('_')[1])))
+                                float(self.function.split('_')[1])))
                     return float(
-                        self.get_count(int(self.function.split('_')[1])))
+                        self.get_count(float(self.function.split('_')[1])))
                 return float(getattr(self, 'get_' + self.function)())
             return float(self.get_last_value())
         return 0


### PR DESCRIPTION
We would like to support also log formats wich log ms instead of seconds. Therefore the percentage calculation needs to be able to parse floats.

Currently we support in only:
TimeSite200:2:count_200_percentage:1min
 
With this patch also fractions are supported:
TimeSite200:2:count_0.200_percentage:1min