### PR TITLE
logfile_values: Make time column position configurable and add function to calculate values distribution

### DIFF
--- a/igcollect/logfile_values.py
+++ b/igcollect/logfile_values.py
@@ -157,7 +157,7 @@ def parse_args():
     parser = ArgumentParser()
     parser.add_argument('--prefix', default='logfile_values')
     parser.add_argument('--file', default='/var/log/messages')
-    parser.add_argument('--columns-num', default='5', type=int)
+    parser.add_argument('--columns-num', default='0', type=int)
     parser.add_argument('--metric', type=Metric, nargs='+')
     parser.add_argument('--time-column', default='0', type=int)
     parser.add_argument('--time-format', default='%Y-%m-%dT%H:%M:%S%z')
@@ -168,7 +168,7 @@ def parse_args():
 
 def get_metrics_values(line, metrics, time_format, columns_num, time_column):
     fields = line.split()
-    if len(fields) != columns_num:
+    if columns_num and len(fields) != columns_num:
         return True
 
     timestamp = convert_to_timestamp(fields[time_column], time_format)


### PR DESCRIPTION
Needed for parsing nginx access.log to get the distribution of response codes:
```
/usr/bin/python3 -I ./logfile_values.py --prefix=servers.en0w1_twx.software.gentime --file "/var/log/nginx/access.log" --metric "code:8:distribution:1min" --time-column 3 --time-format "[%d/%b/%Y:%H:%M:%S" --arch
servers.en0w1_twx.software.gentime.code.200.0 15 1562854544
servers.en0w1_twx.software.gentime.code.101.0 40 1562854544
servers.en0w1_twx.software.gentime.code.302.0 1 1562854544
```
