### PR TITLE
Fix logvalues with empty TZ environment

### DIFF
--- a/igcollect/logfile_values.py
+++ b/igcollect/logfile_values.py
@@ -23,7 +23,7 @@ import time
 import os
 import gzip
 import logging
-from datetime import datetime, timezone
+import datetime
 
 from os.path import exists
 from argparse import ArgumentParser, ArgumentTypeError
@@ -50,7 +50,8 @@ class Metric:
         self.period = period
         self.values = []  # Container for metric values
         self.last_value = 0
-        self.now = int(datetime.now(timezone.utc).timestamp())
+        self.now = int(datetime.datetime.now(datetime.timezone.utc)
+                       .timestamp())
 
     def get_timeshift(self):
         if self.period:
@@ -258,7 +259,7 @@ def convert_to_timestamp(time_str, time_format):
         if time_format.endswith('z') and time_str[-3] == ':':
             time_str = ''.join(time_str.rsplit(':', 1))
 
-        dt = datetime.strptime(time_str, time_format).utctimetuple()
+        dt = datetime.datetime.strptime(time_str, time_format).utctimetuple()
         timestamp = time.mktime(dt)
     except ValueError:
         timestamp = int(time_str)

--- a/igcollect/logfile_values.py
+++ b/igcollect/logfile_values.py
@@ -23,7 +23,7 @@ import time
 import os
 import gzip
 import logging
-import datetime
+from datetime import datetime, timezone
 
 from os.path import exists
 from argparse import ArgumentParser, ArgumentTypeError
@@ -50,7 +50,7 @@ class Metric:
         self.period = period
         self.values = []  # Container for metric values
         self.last_value = 0
-        self.now = int(datetime.datetime.utcnow().timestamp())
+        self.now = int(datetime.now(timezone.utc).timestamp())
 
     def get_timeshift(self):
         if self.period:
@@ -258,7 +258,7 @@ def convert_to_timestamp(time_str, time_format):
         if time_format.endswith('z') and time_str[-3] == ':':
             time_str = ''.join(time_str.rsplit(':', 1))
 
-        dt = datetime.datetime.strptime(time_str, time_format).utctimetuple()
+        dt = datetime.strptime(time_str, time_format).utctimetuple()
         timestamp = time.mktime(dt)
     except ValueError:
         timestamp = int(time_str)

--- a/igcollect/logfile_values.py
+++ b/igcollect/logfile_values.py
@@ -41,7 +41,7 @@ class Metric:
         parts += [None] * (4 - len(parts))
         self.name, column, function, period = parts
         if period:
-            pattern = re.compile('^\d+[A-Za-z]{1,3}$')
+            pattern = re.compile(r'^\d+[A-Za-z]{1,3}$')
             if not pattern.match(period):
                 raise ArgumentTypeError('Period must have number and unit')
 
@@ -224,7 +224,7 @@ def read_logfile_reverse(filename,
                 # if the previous chunk starts right from the beginning of line
                 # do not concact the segment to the last line of new chunk
                 # instead, yield the segment first
-                if buffer[-1] is not '\n':
+                if buffer[-1] != '\n':
                     lines[-1] += segment
                 else:
                     yield get_metrics_values(
@@ -238,10 +238,12 @@ def read_logfile_reverse(filename,
                     if global_index == 1:
                         get_metrics_last_value(lines[index], metrics)
                     yield get_metrics_values(lines[index], metrics,
-                                             time_format, columns_num, time_column)
+                                             time_format, columns_num,
+                                             time_column)
 
     if segment is not None:
-        yield get_metrics_values(segment, metrics, time_format, columns_num, time_column)
+        yield get_metrics_values(segment, metrics, time_format,
+                                 columns_num, time_column)
 
 
 def convert_to_timestamp(time_str, time_format):
@@ -311,6 +313,7 @@ def main():  # NOQA: C901
                 print(template.format(metric.name + '.' + str(k), v))
         else:
             print(template.format(metric.name, metric.get_metric_value()))
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
`utcnow` returns the wrong values for some reason. From the documentation https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow :

```
This is like now(), but returns the current UTC date and time, as a naive datetime object. An aware current UTC datetime can be obtained by calling datetime.now(timezone.utc). See also now().
```