### PR TITLE
Set R6515 to the same total cpu perf as M640

### DIFF
--- a/igcollect/linux_cpu_perffactor.py
+++ b/igcollect/linux_cpu_perffactor.py
@@ -23,7 +23,8 @@ def main():
         'Intel(R) Xeon(R) CPU E5-2660 v2 @ 2.20GHz': 1.65,
         'Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz': 1.85,
         'Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz': 1.75,
-        'Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz': 1.8
+        'Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz': 1.8,
+        'AMD EPYC 7502P 32-Core Processor': 2.25
     }
     cpufactor = 1.0
 

--- a/igcollect/linux_cpu_perffactor.py
+++ b/igcollect/linux_cpu_perffactor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """igcollect - Linux CPU Performance Factors
 
-Copyright (c) 2016 InnoGames GmbH
+Copyright (c) 2020 InnoGames GmbH
 """
 
 from argparse import ArgumentParser


### PR DESCRIPTION
Set AMD's 7502P 32 cores to be equivalent to the 40 cores of a dual socket Xeon 6148 system.