### PR TITLE
Optimize query to fetch relation sizes

### DIFF
--- a/igcollect/postgres.py
+++ b/igcollect/postgres.py
@@ -126,7 +126,7 @@ def main():
 
         # table size
         for line in execute(conn, ('''
-                SELECT relname, pg_total_relation_size(c.oid)
+                SELECT c.relname, pg_total_relation_size(c.oid)
                 FROM pg_class c
                 LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
                 WHERE c.relkind IN ('r', 'm') AND n.nspname NOT IN ('pg_catalog', 'information_schema')

--- a/igcollect/postgres.py
+++ b/igcollect/postgres.py
@@ -126,11 +126,11 @@ def main():
 
         # table size
         for line in execute(conn, ('''
-                SELECT relname, pg_total_relation_size(relid)
+                SELECT relname, pg_total_relation_size(c.oid)
                 FROM pg_class c
                 LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
                 WHERE c.relkind IN ('r', 'm') AND n.nspname NOT IN ('pg_catalog', 'information_schema')
-                ORDER BY pg_total_relation_size(relid) DESC;
+                ORDER BY pg_total_relation_size(c.oid) DESC;
         ''')):
             print(template.format('table_size', line['relname'], line['pg_total_relation_size']))
 

--- a/igcollect/postgres.py
+++ b/igcollect/postgres.py
@@ -125,12 +125,13 @@ def main():
                 print(template.format('bgwriter', key, value))
 
         # table size
-        for line in execute(conn, (
-                'SELECT relname,'
-                '    pg_total_relation_size(relid)'
-                "FROM pg_catalog.pg_statio_user_tables ORDER BY pg_total_relation_size(relid)"
-                "DESC;"
-        )):
+        for line in execute(conn, ('''
+                SELECT relname, pg_total_relation_size(relid)
+                FROM pg_class c
+                LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE c.relkind IN ('r', 'm') AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+                ORDER BY pg_total_relation_size(relid) DESC;
+        ''')):
             print(template.format('table_size', line['relname'], line['pg_total_relation_size']))
 
         # Autovacuum


### PR DESCRIPTION
Hi,

rather than relying on `pg_statio_user_tables` that is doing way more than needed here, we just get the user table names
from `pg_class` and get their corresponding total relation size. By that we avoid some joins on `pg_index`, aggregation and function calls that we are not interested in here anyway.

Since `pg_total_relation_size(relid)` is acquiring an access share lock on the specific relation and therefore on all user tables, the query should be as fast as possible.

Scenario with quite some toast tables (600-700)
Before
```
| Execution Time: 21.253 ms
```
After
```
| Execution Time: 6.678 ms
```