### PR TITLE
Update AMD EPYC perfactors

### DIFF
--- a/igcollect/linux_cpu_perffactor.py
+++ b/igcollect/linux_cpu_perffactor.py
@@ -27,7 +27,8 @@ def main():
         'Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz': 1.75,
         'Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz': 1.8,
         'Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz': 1.875,
-        'AMD EPYC 7502P 32-Core Processor': 2.25
+        'AMD EPYC 7502P 32-Core Processor': 3.6,
+        'AMD EPYC 7763 64-Core Processor': 3.6,
     }
     cpufactor = 1.0
 


### PR DESCRIPTION
From the latest estimations, the former perffactor for AMD was wrong. Changed for AMD EPYC 7502P and added for AMD EPYC 7763.