### PR TITLE
fix syntax error in redis.py

### DIFF
--- a/igcollect/redis.py
+++ b/igcollect/redis.py
@@ -58,7 +58,7 @@ def main():
         'total_commands_processed',
     )
     for metric in headers:
-        print(template.format(metric, redis_stats.get(metric))
+        print(template.format(metric, redis_stats.get(metric)))
 
 
 def get_redis_conf(*args):


### PR DESCRIPTION
```
File "redis.py", line 64
    def get_redis_conf(*args):
    ^
SyntaxError: invalid syntax
```