### PR TITLE
Split at first colon; values may have colons

### DIFF
--- a/igcollect/redis.py
+++ b/igcollect/redis.py
@@ -30,7 +30,7 @@ def main():
     redis_stats = {}
     for x in redis_info.splitlines():
         if x.find(b':') != -1:
-            key, value = x.split(b':')
+            key, value = x.split(b':', 1)
             redis_stats[key.decode('utf-8')] = value.decode('utf-8')
 
     template = args.prefix + '.{} {} ' + str(int(time()))


### PR DESCRIPTION
Since Redis 7, our config has a bind on ipv6, which contains colon characters (`:`).
Since these are only ever found in the value, not in the key, we can be more specific with our split and only split at the first column of the line.
